### PR TITLE
Add GitHub Actions for automated PR workflows - TEST

### DIFF
--- a/.github/workflows/dev_to_main.yml
+++ b/.github/workflows/dev_to_main.yml
@@ -1,0 +1,57 @@
+name: Dev to Main Auto PR
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - dev
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dev-main-pr:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check open PRs to dev
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          OPEN_PRS=$(gh pr list --base dev --state open --json number --jq length)
+
+          if [ "$OPEN_PRS" -ne 0 ]; then
+            echo "There are still open PRs to dev"
+            exit 0
+          fi
+
+      - name: Create dev to main PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cat <<EOF > pr_body.md
+🤖 **Pull Request di rilascio automatica**
+
+Tutti i branch sono stati integrati in \`dev\`.
+Questa PR avvia il merge finale verso \`main\`.
+
+---
+
+⚠️ **PR automatica**
+Non è stata aperta manualmente dal team.
+EOF
+
+          gh pr create \
+            --head dev \
+            --base main \
+            --title "[PR AUTO] main <- dev | release" \
+            --body-file pr_body.md \
+            --label "release" \
+            || echo "PR dev -> main già esistente"
+
+          gh pr merge dev \
+            --auto \
+            --merge \
+            || true

--- a/.github/workflows/night_prs.yml
+++ b/.github/workflows/night_prs.yml
@@ -1,0 +1,80 @@
+name: Nightly Branch to Dev PRs
+
+on:
+  schedule:
+    - cron: '50 10 * * *' # Mettere mercoledì alle 00.30 dopo, ora solo per testing lo ho cambiato...
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  create-prs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch all branches
+        run: git fetch --all
+
+      - name: Create PRs from branches to dev
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DATE=$(date +'%Y-%m-%d')
+
+          for branch in $(git branch -r | grep origin/ | sed 's|origin/||'); do
+            if [[ "$branch" == "dev" || "$branch" == "main" ]]; then
+              continue
+            fi
+
+            COMMITS=$(git log dev..origin/$branch \
+              --pretty=format:"- %s (%an)")
+
+            if [ -z "$COMMITS" ]; then
+              continue
+            fi
+
+            cat <<EOF > pr_body.md
+🤖 **Pull Request generata automaticamente**
+
+Questa PR è stata creata da una GitHub Action schedulata.
+
+---
+
+### 🔀 Branch
+\`$branch\`
+
+### 🎯 Integrazione
+\`dev <- $branch\`
+
+---
+
+### 📦 Modifiche incluse
+
+$COMMITS
+
+---
+
+⚠️ **PR automatica**
+Non è stata aperta manualmente dal team.
+EOF
+
+            gh pr create \
+              --head "$branch" \
+              --base dev \
+              --title "[PR AUTO] dev <- $branch | $DATE" \
+              --body-file pr_body.md \
+              --label "auto-pr" \
+              || echo "PR già esistente per $branch"
+
+            gh pr merge "$branch" \
+              --auto \
+              --merge \
+              || true
+          done

--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@ Sistema di gestione delle gare agonistiche di pesca in provincia di Bergamo.
 
 ## Panoramica
 - Tecnologie: Eclipse (Java), GitHub, Papyrus, PlantUML  
-- Team: 4 sviluppatori universitari – ruoli SCM definiti nel [Piano Gestione della Configurazione.pdf](https://github.com/ABCLV/ABLV_IngSW/blob/dev/ABLV_IngSW/docs/Piano%20Gestione%20della%20Configurazione.pdf). 
+- Team: 4 sviluppatori universitari – ruoli SCM definiti nel [Piano Gestione della Configurazione.pdf](./docs/Piano%20Gestione%20della%20Configurazione.md). 
 - Metodologia: Scrum settimanale, sprint 1 settimana  
 
 ## Documentazione di progetto
 nella cartella docs/
 | File | Descrizione |
 |------|-------------|
-| [Piano Gestione della Configurazione.pdf](https://github.com/ABCLV/ABLV_IngSW/blob/dev/ABLV_IngSW/docs/Piano%20Gestione%20della%20Configurazione.pdf). | Processo SCM, branching model, ruoli e responsabilità |
-| [Proposta gare di pesca.pdf](https://github.com/ABCLV/ABLV_IngSW/blob/dev/ABLV_IngSW/docs/Proposta%20gare%20di%20pesca.pdf) | Requisiti funzionali, regole di business, attori e casi d’uso |
-| [scrumsebacklogs/](https://github.com/ABCLV/ABLV_IngSW/tree/dev/ABLV_IngSW/docs/scrumsebacklogs) | Sprint backlog, stato avanzamento, decisioni prese |
-| [diagrams/](https://github.com/ABCLV/ABLV_IngSW/tree/dev/ABLV_IngSW/docs/diagrams) | Diagrammi UML: classi, casi d’uso, stato, sequenza |
+| [Piano Gestione della Configurazione.pdf](./docs/Piano%20Gestione%20della%20Configurazione.md). | Processo SCM, branching model, ruoli e responsabilità |
+| [Proposta gare di pesca.pdf](./docs/Proposta.md) | Requisiti funzionali, regole di business, attori e casi d’uso |
+| [scrumsebacklogs/](./docs/scrumsebacklogs/) | Sprint backlog, stato avanzamento, decisioni prese |
+| [diagrams/](./diagrams/) | Diagrammi UML: classi, casi d’uso, stato, sequenza |
 ## Quick start
 ```bash
 git clone https://github.com/ABCLV/ABLV_IngSW/


### PR DESCRIPTION
Introduces two GitHub Actions: one for automatically creating and merging PRs from 'dev' to 'main' when all PRs to 'dev' are merged, and another for nightly scheduled PRs from feature branches to 'dev'. Updates README links to use relative paths for local documentation references.


# Tipo di modifica
- [ ] Bug fix
- [X] Nuova funzionalità
- [ ] Modifica di documentazione
- [ ] Refactoring
- [ ] Nuovo diagramma
- [ ] Altro (Specifica cosa)

# Checklist
- [ ] Ho eseguito `mvn test` localmente senza errori
- [ ] Ho aggiornato la documentazione (se necessario)
- [X] Il codice rispetta le convenzioni del progetto
- [ ] La PR ha almeno 2 revisori assegnati

# prima di confermare verificare la destinazione della pr
