### PR TITLE
Update night_prs workflow and remove GH CLI setup

### DIFF
--- a/.github/workflows/night_prs.yml
+++ b/.github/workflows/night_prs.yml
@@ -1,7 +1,7 @@
 name: Auto PR from feature branches to dev
 
 on:
-  workflow_dispatch:  # esecuzione manuale
+  workflow_dispatch:  # per esecuzione manuale
   schedule:
     - cron: '0 0 * * *'  # Tra martedì e mercoledì a mezzanotte
 
@@ -19,9 +19,6 @@ jobs:
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-
-    - name: Install GitHub CLI
-      uses: actions/setup-gh-cli@v2
 
     - name: Generate PRs from feature branches
       run: |


### PR DESCRIPTION
Corrects a comment for manual workflow dispatch and removes the step that installs the GitHub CLI, as it is no longer needed.

# Descrizione
Breve riassunto di ciò che la PR fa e perché è necessaria.

# Tipo di modifica
- [ ] Bug fix
- [ ] Nuova funzionalità
- [ ] Modifica di documentazione
- [ ] Refactoring
- [ ] Nuovo diagramma
- [ ] Altro (Specifica cosa)

# Checklist
- [ ] Ho eseguito `mvn test` localmente senza errori
- [ ] Ho aggiornato la documentazione (se necessario)
- [ ] Il codice rispetta le convenzioni del progetto
- [ ] La PR ha almeno 2 revisori assegnati

# !! non dimenticarti di mettere gli id degli issue così si chiudono in automatico !!
Issue collegate (scrivi qui sotto)

Closes #

# prima di confermare verificare la destinazione della pr
